### PR TITLE
New AbstractCache option: per_user (defaulting to true)

### DIFF
--- a/src/AbstractCache.php
+++ b/src/AbstractCache.php
@@ -12,11 +12,13 @@ abstract class AbstractCache
     protected $zone = null;
 
     /**
-     * Whether this cache should be per user
+     * Whether this cache should be per user; configure to false to share the cache
      * Defaults to true
      * @var bool $per_user
      */
     protected $per_user = true;
+
+    protected $user_id_for_shared_cache = 0;
 
     /**
      * Expire cached value after given seconds
@@ -50,6 +52,10 @@ abstract class AbstractCache
 
         if (isset($config['per_user'])) {
             $this->per_user = $config['per_user'];
+        }
+
+        if (isset($config['user_id_for_shared_cache'])) {
+            $this->user_id_for_shared_cache = $config['user_id_for_shared_cache'];
         }
 
         $this->backend = $config['backend'] ?? null;

--- a/src/AbstractCache.php
+++ b/src/AbstractCache.php
@@ -12,6 +12,13 @@ abstract class AbstractCache
     protected $zone = null;
 
     /**
+     * Whether this cache should be per user
+     * Defaults to true
+     * @var bool $per_user
+     */
+    protected $per_user = true;
+
+    /**
      * Expire cached value after given seconds
      */
     protected $expire = null;
@@ -39,6 +46,10 @@ abstract class AbstractCache
             $this->zone = 'default';
         } else {
             $this->zone = $config['zone'];
+        }
+
+        if (isset($config['per_user'])) {
+            $this->per_user = $config['per_user'];
         }
 
         $this->backend = $config['backend'] ?? null;

--- a/src/FieldCache.php
+++ b/src/FieldCache.php
@@ -120,7 +120,7 @@ class FieldCache extends AbstractCache
         $field_name = Utils::sanitize($this->field_name);
         $args_hash = Utils::hash(Utils::stable_string($args));
         $query_hash = Utils::hash($this->query);
-        $user_id = $this->per_user ? get_current_user_id() : 0;
+        $user_id = $this->per_user ? get_current_user_id() : $this->user_id_for_shared_cache;
 
         $this->key = "field-{$query_name}-${field_name}-${user_id}-{$query_hash}-${args_hash}";
 

--- a/src/FieldCache.php
+++ b/src/FieldCache.php
@@ -120,7 +120,7 @@ class FieldCache extends AbstractCache
         $field_name = Utils::sanitize($this->field_name);
         $args_hash = Utils::hash(Utils::stable_string($args));
         $query_hash = Utils::hash($this->query);
-        $user_id = get_current_user_id();
+        $user_id = $this->per_user ? get_current_user_id() : 0;
 
         $this->key = "field-{$query_name}-${field_name}-${user_id}-{$query_hash}-${args_hash}";
 

--- a/src/QueryCache.php
+++ b/src/QueryCache.php
@@ -70,7 +70,7 @@ class QueryCache extends AbstractCache
             return;
         }
 
-        $user_id = $this->per_user ? get_current_user_id() : 0;
+        $user_id = $this->per_user ? get_current_user_id() : $this->user_id_for_shared_cache;
 
         $args_hash = empty($variables)
             ? 'null'

--- a/src/QueryCache.php
+++ b/src/QueryCache.php
@@ -69,8 +69,8 @@ class QueryCache extends AbstractCache
         if (empty($query)) {
             return;
         }
-        
-        $user_id = get_current_user_id();
+
+        $user_id = $this->per_user ? get_current_user_id() : 0;
 
         $args_hash = empty($variables)
             ? 'null'


### PR DESCRIPTION
Currently, all cache keys use the user ID, meaning that all caches are per user. It is not possible to cache a query and have that cache shared by both visitors and logged-in users.

This adds the ability to define `per_user` as false in the config passed to any implementation of `AbstractCache`, allowing a cache to be shared by all users.