### PR TITLE
Permit FieldCache and QueryCache keys to be filtered

### DIFF
--- a/src/FieldCache.php
+++ b/src/FieldCache.php
@@ -122,7 +122,8 @@ class FieldCache extends AbstractCache
         $query_hash = Utils::hash($this->query);
         $user_id = get_current_user_id();
 
-        $this->key = "field-{$query_name}-${field_name}-${user_id}-{$query_hash}-${args_hash}";
+        $key = "field-{$query_name}-{$field_name}-{$user_id}-{$query_hash}-{$args_hash}";
+        $this->key = apply_filters('graphql_cache_field_key', $key, $user_id, $this->query_name, $this->query, $this->field_name, $args);
 
         $this->read_cache();
 

--- a/src/QueryCache.php
+++ b/src/QueryCache.php
@@ -78,7 +78,8 @@ class QueryCache extends AbstractCache
 
         $query_hash = Utils::hash($query);
 
-        $this->key = "query-{$this->query_name}-${user_id}-{$query_hash}-${args_hash}";
+        $key = "query-{$this->query_name}-{$user_id}-{$query_hash}-{$args_hash}";
+        $this->key = apply_filters('graphql_cache_query_key', $key, $user_id, $this->query_name, $query, $variables);
 
         $this->read_cache();
 


### PR DESCRIPTION
Currently, the cache key used in `QueryCache` and `FieldCache` cannot be filtered.

This PR adds the following two filter hooks:

`graphql_cache_query_key`
`graphql_cache_field_key`