### PR TITLE
Adding a filter to turn off logging

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -30,6 +30,10 @@ class Utils
 
     static function log(string $msg, $data = null)
     {
+        if (!apply_filters('graphql_cache_logging', true)) {
+            return;
+        }
+
         if (null !== $data) {
             $msg .= ' ' . print_r($data, true);
         }


### PR DESCRIPTION
Currently, every cache write and hit results in an error_log entry.

This PR adds a new filter hook to turn off logging:

`graphql_cache_logging`

It could be used in this fashion:

```php
    add_filter(
        'graphql_cache_logging',
        function () {
            return false;
        },
        10, 0
    );
```