### PR TITLE
Supporting query batching

### DIFF
--- a/src/CacheManager.php
+++ b/src/CacheManager.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace WPGraphQL\Extensions\Cache;
 
-use WPGraphQL\Request;class CacheManager
+use WPGraphQL\Request;
+
+class CacheManager
 {
     static $fields = [];
 

--- a/src/QueryCache.php
+++ b/src/QueryCache.php
@@ -4,13 +4,18 @@ declare(strict_types=1);
 
 namespace WPGraphQL\Extensions\Cache;
 
-use WPGraphQL\Extensions\Cache\Backend\AbstractBackend;
+use GraphQL\Executor\ExecutionResult;use GraphQL\Server\OperationParams;use GraphQL\Server\StandardServer;use WPGraphQL\Extensions\Cache\Backend\AbstractBackend;use WPGraphQL\Request;
 
 /**
  * Class that takes care of caching of full queries
  */
 class QueryCache extends AbstractCache
 {
+
+    static protected $hits = 0;
+    static protected $misses = 0;
+    static protected $headers_sent = false;
+
     /**
      * GraphQL Query name this cache should match against
      */
@@ -37,22 +42,7 @@ class QueryCache extends AbstractCache
             $this->backend = $backend;
         }
 
-        add_action(
-            'do_graphql_request',
-            [$this, '__action_do_graphql_request'],
-            10,
-            4
-        );
-
-        add_action(
-            'graphql_process_http_request_response',
-            [$this, '__action_graphql_process_http_request_response'],
-            // Use large value as this should be the last response filter
-            // because we want to save the last version of the response to the
-            // cache.
-            1000,
-            5
-        );
+        add_filter('process_graphql_execute_request', [$this, '__filter_do_graphql_request'], 10, 2);
 
         add_action('graphql_response_set_headers', [
             $this,
@@ -60,104 +50,93 @@ class QueryCache extends AbstractCache
         ]);
     }
 
-    function __action_do_graphql_request(
-        ?string $query,
-        $operation,
-        $variables,
-        $params
-    ) {
+    /**
+    * @param ExecutionResult|null $response
+    * @param OperationParams $params
+    * @return ExecutionResult|array|null
+    */
+    function __filter_do_graphql_request($response, $params)
+    {
+
+        $query = $params->query;
+
         if (empty($query)) {
-            return;
+            return $response;
         }
 
-        $user_id = $this->per_user ? get_current_user_id() : $this->user_id_for_shared_cache;
+        if (!$this->cache_matches_query($params)) {
+            return $response;
+        }
 
-        $args_hash = empty($variables)
+        $user_id = $this->per_user ? get_current_user_id() : 0;
+
+        $args_hash = empty($params->variables)
             ? 'null'
-            : Utils::hash(Utils::stable_string($variables));
+            : Utils::hash(Utils::stable_string($params->variables));
 
         $query_hash = Utils::hash($query);
 
-        $key = "query-{$this->query_name}-{$user_id}-{$query_hash}-{$args_hash}";
-        $this->key = apply_filters('graphql_cache_query_key', $key, $user_id, $this->query_name, $query, $variables);
+        $this->key = "query-{$this->query_name}-{$user_id}-{$query_hash}-{$args_hash}";
 
         $this->read_cache();
 
         if ($this->has_hit()) {
-            // Respond from the cache as early as possible to avoid graphql
-            // query parsing etc.
-            Utils::log('HIT query cache');
-            $this->respond_and_exit();
+            Utils::log('HIT query cache: ' . $this->key);
+
+            return json_decode($this->get_cached_data() ?? '', true);
         }
 
-        $current_query_name = Utils::get_query_name($query);
+        Utils::log('MISS query cache: ' . $this->key);
 
-        // If wildcard is passed just mark the cache as matched
-        if ($this->query_name === '*') {
-            $this->match = true;
-            return;
+        $response = do_graphql_request($params->query, $params->operation, $params->variables);
+
+        if (empty($response->errors)) {
+
+            // Save results as pre encoded json
+            $this->backend->set(
+                $this->zone,
+                $this->get_cache_key(),
+                new CachedValue(wp_json_encode($response)),
+                $this->expire
+            );
+
+            Utils::log('Writing QueryCache ' . $this->key);
+
         }
 
-        // Otherwise check it matches with registered query name
-        $this->match = $this->query_name === $current_query_name;
+        return $response;
     }
 
     function __action_graphql_response_set_headers()
     {
-        if (!$this->has_match()) {
+
+        if (self::$headers_sent) {
             return;
         }
 
-        // Just add MISS header if we have match and have not already exited
-        // with the cached response. respond_and_exit() handles the HIT header
-        header('x-graphql-query-cache: MISS');
-    }
-
-    function __action_graphql_process_http_request_response(
-        $response,
-        $result,
-        $operation_name,
-        $query,
-        $variables
-    ) {
-        if (!$this->has_match()) {
-            return;
+        if (self::$hits && self::$misses) {
+            header('x-graphql-query-cache: MIXED');
+        }
+        elseif (self::$hits) {
+            header('x-graphql-query-cache: HIT');
+        }
+        else {
+            header('x-graphql-query-cache: MISS');
         }
 
-        if (!empty($response->errors)) {
-            return;
-        }
+        self::$headers_sent = true;
 
-        // Save results as pre encoded json
-        $this->backend->set(
-            $this->zone,
-            $this->get_cache_key(),
-            new CachedValue(wp_json_encode($response)),
-            $this->expire
-        );
-        Utils::log('Writing QueryCache ' . $this->key);
-    }
-
-    function respond_and_exit()
-    {
-        header(
-            'Content-Type: application/json; charset=' .
-                get_option('blog_charset')
-        );
-        header('x-graphql-query-cache: HIT');
-
-        do_action('graphql_cache_early_response');
-
-        // We stored the encoded JSON string so we can just respond with it here
-        echo $this->get_cached_data();
-        die();
     }
 
     /**
-     * Returns true when query should be cached
-     */
-    function has_match(): bool
-    {
-        return $this->match;
+     * @param OperationParams $params
+     * @return bool
+    */
+    protected function cache_matches_query($params) {
+
+        $current_name = $params->operation ?: Utils::get_query_name($params->query);
+
+        return $this->query_name === $current_name || $this->query_name === '*';
+
     }
 }

--- a/src/QueryCache.php
+++ b/src/QueryCache.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace WPGraphQL\Extensions\Cache;
 
-use GraphQL\Executor\ExecutionResult;use GraphQL\Server\OperationParams;use GraphQL\Server\StandardServer;use WPGraphQL\Extensions\Cache\Backend\AbstractBackend;use WPGraphQL\Request;
+use GraphQL\Executor\ExecutionResult;
+use GraphQL\Server\OperationParams;
+use WPGraphQL\Extensions\Cache\Backend\AbstractBackend;
 
 /**
  * Class that takes care of caching of full queries


### PR DESCRIPTION
In order to support batched queries, it was necessary to change the way the plugin hooks into WPGraphQL. It was no longer possible to exit early, echoing the result, because there might be other queries afterwards that require resolving. As such, we're now hooking in very early in WPGraphQL's process, and replacing the execution process entirely.